### PR TITLE
Fix: fix bug in md-button

### DIFF
--- a/src/components/md-button/index.vue
+++ b/src/components/md-button/index.vue
@@ -78,10 +78,20 @@
 
         // console.log(x, y)
 
-        btn.appendChild(ripple)
+        // ensure there is no ripple before add
+        if (this.ripple) {
+          btn.removeChild(this.ripple)
+          this.ripple = null
+        }
+
+        this.ripple = ripple
+        btn.appendChild(this.ripple)
 
         setTimeout(() => {
-          btn.removeChild(ripple)
+          if (this.ripple && btn.contains(this.ripple)) {
+            btn.removeChild(this.ripple)
+            this.ripple = null
+          }
         }, 2000)
       }
     }


### PR DESCRIPTION
在快速点击按钮时，由于上一次点击效果需要在两秒后移除，所以会使得上一次点击效果重放。因此，在动画效果出现之时应确保上一次效果已经被移除。
```javascript
// ensure there is no ripple before add
if (this.ripple) {
  btn.removeChild(this.ripple)
  this.ripple = null
}
```